### PR TITLE
Added precision argument to BBox.to_string()

### DIFF
--- a/src/osdatahub/NamesAPI/names_api.py
+++ b/src/osdatahub/NamesAPI/names_api.py
@@ -66,7 +66,7 @@ class NamesAPI:
         if bounds:
             if not bounds.crs == "EPSG:27700":
                 raise TypeError("Bounds must be in British National Grid CRS (EPSG:27700)")
-            params.update({"bounds": bounds.bbox.to_string()})
+            params.update({"bounds": bounds.bbox.to_string(precision=2)})
         if bbox_filter or local_type:
             if bbox_filter and (not bbox_filter.crs == "EPSG:27700"):
                 raise TypeError("Bounding Box filter must be in British National Grid CRS (EPSG:27700)")
@@ -149,7 +149,7 @@ class NamesAPI:
             if not bbox_filter.crs == "EPSG:27700":
                 raise ValueError("'bbox_filter' argument must have CRS of British National Grid (EPSG:27700). Its CRS "
                                  f"is {bbox_filter.crs}")
-            fq_args.append("BBOX:" + str(bbox_filter.bbox.to_string()))
+            fq_args.append("BBOX:" + str(bbox_filter.bbox.to_string(precision=2)))
 
         return fq_args
 

--- a/src/osdatahub/bbox.py
+++ b/src/osdatahub/bbox.py
@@ -19,11 +19,14 @@ class BBox:
     def __getitem__(self, index):
         return list(self)[index]
 
-    def to_string(self) -> str:
+    def to_string(self, precision: int = None) -> str:
         """
         Converts bounding box into string
+
+        Args:
+            precision (int): Decimal point rounding precision. Defaults to None (no rounding)
 
         Returns:
             str: bounding box in string form
         """
-        return ",".join(str(c) for c in self)
+        return ",".join(str(round(c, precision) if precision is not None else c) for c in self)


### PR DESCRIPTION
Added precision argument to BBox.to_string() function in bbox.py and implemented it with bbox_filter and bounds in names_api.py. This fixes an issue where the API will error out if given bounds or bbox_filter with greater than 2 decimals of precision #7 