### PR TITLE
Add old api warning

### DIFF
--- a/src/osdatahub/FeaturesAPI/feature_products.py
+++ b/src/osdatahub/FeaturesAPI/feature_products.py
@@ -109,6 +109,110 @@ OPEN = {
 }
 
 
+OPEN_NEW = {
+    "zoomstack_district_buildings": Product("Zoomstack_DistrictBuildings", "MultiPolygon"),
+    "zoomstack_foreshore": Product("Zoomstack_Foreshore", "MultiPolygon"),
+    "zoomstack_greenspace": Product("Zoomstack_Greenspace", "MultiPolygon"),
+    "zoomstack_local_buildings": Product("Zoomstack_LocalBuildings", "MultiPolygon"),
+    "zoomstack_national_parks": Product("Zoomstack_NationalParks", "MultiPolygon"),
+    "zoomstack_sites": Product("Zoomstack_Sites", "MultiPolygon"),
+    "zoomstack_surface_water": Product("Zoomstack_Surfacewater", "MultiPolygon"),
+    "zoomstack_urban_areas": Product("Zoomstack_UrbanAreas", "MultiPolygon"),
+    "zoomstack_woodland": Product("Zoomstack_Woodland", "MultiPolygon"),
+    "zoomstack_boundaries": Product("Zoomstack_Boundaries", "MultiLineString"),
+    "zoomstack_contours": Product("Zoomstack_Contours", "MultiLineString"),
+    "zoomstack_ETL": Product("Zoomstack_ETL", "MultiLineString"),
+    "zoomstack_rail": Product("Zoomstack_Rail", "MultiLineString"),
+    "zoomstack_roads_local": Product("Zoomstack_RoadsLocal", "MultiLineString"),
+    "zoomstack_roads_national": Product("Zoomstack_RoadsNational", "MultiLineString"),
+    "zoomstack_roads_regional": Product("Zoomstack_RoadsRegional", "MultiLineString"),
+    "zoomstack_waterlines": Product("Zoomstack_Waterlines", "MultiLineString"),
+    "open_USRN": Product("OpenUSRN_USRN", "MultiLineString"),
+    "zoomstack_airports": Product("Zoomstack_Airports", "Point"),
+    "zoomstack_names": Product("Zoomstack_Names", "Point"),
+    "zoomstack_railway_stations": Product("Zoomstack_RailwayStations", "Point"),
+    "openUPRN_address": Product("OpenUPRN_Address", "Point"),
+    "openTOID_highways_network": Product("OpenTOID_HighwaysNetwork", "Point"),
+    "openTOID_sites": Product("OpenTOID_SitesLayer", "Point"),
+    "openTOID_topography": Product("OpenTOID_TopographyLayer", "Point"),
+    "Zoomstack_DistrictBuildings": Product("Zoomstack_DistrictBuildings", "MultiPolygon"),
+    "Zoomstack_Foreshore": Product("Zoomstack_Foreshore", "MultiPolygon"),
+    "Zoomstack_Greenspace": Product("Zoomstack_Greenspace", "MultiPolygon"),
+    "Zoomstack_LocalBuildings": Product("Zoomstack_LocalBuildings", "MultiPolygon"),
+    "Zoomstack_NationalParks": Product("Zoomstack_NationalParks", "MultiPolygon"),
+    "Zoomstack_Sites": Product("Zoomstack_Sites", "MultiPolygon"),
+    "Zoomstack_Surfacewater": Product("Zoomstack_Surfacewater", "MultiPolygon"),
+    "Zoomstack_UrbanAreas": Product("Zoomstack_UrbanAreas", "MultiPolygon"),
+    "Zoomstack_Woodland": Product("Zoomstack_Woodland", "MultiPolygon"),
+    "Zoomstack_Boundaries": Product("Zoomstack_Boundaries", "MultiLineString"),
+    "Zoomstack_Contours": Product("Zoomstack_Contours", "MultiLineString"),
+    "Zoomstack_ETL": Product("Zoomstack_ETL", "MultiLineString"),
+    "Zoomstack_Rail": Product("Zoomstack_Rail", "MultiLineString"),
+    "Zoomstack_RoadsLocal": Product("Zoomstack_RoadsLocal", "MultiLineString"),
+    "Zoomstack_RoadsNational": Product("Zoomstack_RoadsNational", "MultiLineString"),
+    "Zoomstack_RoadsRegional": Product("Zoomstack_RoadsRegional", "MultiLineString"),
+    "Zoomstack_Waterlines": Product("Zoomstack_Waterlines", "MultiLineString"),
+    "OpenUSRN_USRN": Product("OpenUSRN_USRN", "MultiLineString"),
+    "Zoomstack_Airports": Product("Zoomstack_Airports", "Point"),
+    "Zoomstack_Names": Product("Zoomstack_Names", "Point"),
+    "Zoomstack_RailwayStations": Product("Zoomstack_RailwayStations", "Point"),
+    "openUPRN_address": Product("OpenUPRN_Address", "Point"),
+    "OpenTOID_HighwaysNetwork": Product("OpenTOID_HighwaysNetwork", "Point"),
+    "OpenTOID_SitesLayer": Product("OpenTOID_SitesLayer", "Point"),
+    "OpenTOID_TopographyLayer": Product("OpenTOID_TopographyLayer", "Point")
+}
+
+PREMIUM_NEW = {
+    "topographic_area": Product("Topography_TopographicArea", "MultiPolygon"),
+    "topographic_point": Product("Topography_TopographicPoint", "Point"),
+    "topographic_line": Product("Topography_TopographicLine", "MultiLineString"),
+    "water_network_link": Product("WaterNetwork_WatercourseLink", "MultiLineString"),
+    "water_network_node": Product("WaterNetwork_HydroNode", "Point"),
+    "path_network_link": Product("DetailedPathNetwork_RouteLink", "MultiLineString"),
+    "path_network_node": Product("DetailedPathNetwork_RouteNode", "Point"),
+    "highways_connecting_link": Product("Highways_ConnectingLink", "MultiLineString"),
+    "highways_connecting_node": Product("Highways_ConnectingNode", "Point"),
+    "highways_ferry_link": Product("Highways_FerryLink", "MultiLineString"),
+    "highways_ferry_node": Product("Highways_FerryNode", "Point"),
+    "highways_path_link": Product("Highways_PathLink", "MultiLineString"),
+    "highways_path_node": Product("Highways_PathNode", "Point"),
+    "highways_road_link": Product("Highways_RoadLink", "MultiLineString"),
+    "highways_road_node": Product("Highways_RoadNode", "Point"),
+    "highways_street": Product("Highways_Street", "MultiLineString"),
+    "greenspace_area": Product("Greenspace_GreenspaceArea", "MultiPolygon"),
+    "sites_access_point": Product("Sites_AccessPoint", "Point"),
+    "sites_functional_site": Product("Sites_FunctionalSite", "MultiPolygon"),
+    "sites_routing_point": Product("Sites_RoutingPoint", "Point"),
+    "topographic_boundary": Product("Topography_BoundaryLine", "MultiLineString"),
+    "cartographic_symbol": Product("Topography_CartographicSymbol", "Point"),
+    "cartographic_text": Product("Topography_CartographicText", "Point"),
+
+    "Topography_TopographicArea": Product("Topography_TopographicArea", "MultiPolygon"),
+    "Topography_TopographicPoint": Product("Topography_TopographicPoint", "Point"),
+    "Topography_TopographicLine": Product("Topography_TopographicLine", "MultiLineString"),
+    "WaterNetwork_WatercourseLink": Product("WaterNetwork_WatercourseLink", "MultiLineString"),
+    "WaterNetwork_HydroNode": Product("WaterNetwork_HydroNode", "Point"),
+    "DetailedPathNetwork_RouteLink": Product("DetailedPathNetwork_RouteLink", "MultiLineString"),
+    "DetailedPathNetwork_RouteNode": Product("DetailedPathNetwork_RouteNode", "Point"),
+    "Highways_ConnectingLink": Product("Highways_ConnectingLink", "MultiLineString"),
+    "Highways_ConnectingNode": Product("Highways_ConnectingNode", "Point"),
+    "Highways_FerryLink": Product("Highways_FerryLink", "MultiLineString"),
+    "Highways_FerryNode": Product("Highways_FerryNode", "Point"),
+    "Highways_PathLink": Product("Highways_PathLink", "MultiLineString"),
+    "Highways_PathNode": Product("Highways_PathNode", "Point"),
+    "Highways_RoadLink": Product("Highways_RoadLink", "MultiLineString"),
+    "Highways_RoadNode": Product("Highways_RoadNode", "Point"),
+    "Highways_Street": Product("Highways_Street", "MultiLineString"),
+    "Greenspace_GreenspaceArea": Product("Greenspace_GreenspaceArea", "MultiPolygon"),
+    "Sites_AccessPoint": Product("Sites_AccessPoint", "Point"),
+    "Sites_FunctionalSite": Product("Sites_FunctionalSite", "MultiPolygon"),
+    "Sites_RoutingPoint": Product("Sites_RoutingPoint", "Point"),
+    "Topography_BoundaryLine": Product("Topography_BoundaryLine", "MultiLineString"),
+    "Topography_CartographicSymbol": Product("Topography_CartographicSymbol", "Point"),
+    "Topography_CartographicText": Product("Topography_CartographicText", "Point")
+}
+
+
 def suggest_product(text: str) -> list:
     matches = []
     for product_name in OPEN:
@@ -132,10 +236,13 @@ def validate_product_name(product_name: str) -> str:
         f"\tPremium Products: {', '.join(list(PREMIUM))}\n\n")
 
 
-def get_product(product_name: str):
-    if product_name in PREMIUM:
-        return PREMIUM[product_name]
-    elif product_name in OPEN:
-        return OPEN[product_name]
+def get_product(product_name: str, new_api: bool = False) -> Product:
+    premium_lookup = PREMIUM_NEW if new_api else PREMIUM
+    open_lookup = OPEN_NEW if new_api else OPEN
+    if product_name in premium_lookup:
+        return premium_lookup[product_name]
+    elif product_name in open_lookup:
+        return open_lookup[product_name]
     else:
         raise ValueError(f"{product_name} is not a valid product name")
+

--- a/src/osdatahub/FeaturesAPI/features_api.py
+++ b/src/osdatahub/FeaturesAPI/features_api.py
@@ -103,7 +103,11 @@ class FeaturesAPI:
                 n_required = min(100, limit - len(data))
         except json.decoder.JSONDecodeError:
             raise_http_error(response)
-        return features_to_geojson(data.values, self.product.geometry,
+        if len(data) and data.values[0]["geometry"]["type"] == "MultiLineString" and "GmlID" in data.values[0]["properties"].keys():
+            geom = "MultiLineString"
+        else:
+            geom = self.product.geometry
+        return features_to_geojson(data.values, geom,
                                    self.extent.crs)
 
     def __construct_filter(self) -> str:

--- a/src/osdatahub/FeaturesAPI/features_api.py
+++ b/src/osdatahub/FeaturesAPI/features_api.py
@@ -1,4 +1,6 @@
 import json
+import warnings
+
 import requests
 from geojson import FeatureCollection
 
@@ -8,7 +10,7 @@ from osdatahub.FeaturesAPI.feature_products import (get_product,
                                                     validate_product_name)
 from osdatahub.grow_list import GrowList
 from osdatahub.spatial_filter_types import SpatialFilterTypes
-from osdatahub.utils import features_to_geojson
+from osdatahub.utils import features_to_geojson, is_new_api
 from typeguard import check_argument_types
 
 
@@ -101,10 +103,16 @@ class FeaturesAPI:
                 if "crs" in response.json().keys():
                     self.new_api = True
                     self.product = self.__product_name
+
                 data.extend(response.json()["features"])
                 n_required = min(100, limit - len(data))
         except json.decoder.JSONDecodeError:
             raise_http_error(response)
+        if not is_new_api(data):
+            warnings.warn("The OS Data Hub  has updated the Features API, fixing some important bugs and adding some "
+                          "new properties to all responses.\nTo access these features, consider regenerating your API "
+                          "key in the OS Data Hub API dashboard. \nMore information about the update can be found at"
+                          "osdatahub.os.uk.", DeprecationWarning)
         return features_to_geojson(data.values, self.product.geometry,
                                    self.extent.crs)
 

--- a/src/osdatahub/FeaturesAPI/features_api.py
+++ b/src/osdatahub/FeaturesAPI/features_api.py
@@ -71,7 +71,7 @@ class FeaturesAPI:
         return self.__product
 
     @product.setter
-    def product(self, product_name: str, new_api: bool = False):
+    def product(self, product_name: str):
         product_name = validate_product_name(product_name)
         self.__product = get_product(product_name, self.new_api)
         self.__product_name = product_name

--- a/src/osdatahub/FeaturesAPI/features_api.py
+++ b/src/osdatahub/FeaturesAPI/features_api.py
@@ -112,7 +112,7 @@ class FeaturesAPI:
         filter_body = self.__spatial_filter(self.extent)
         for _filter in self.filters:
             filter_body += _filter
-            filter_body = f"<ogc:and>{filter_body}</ogc:and>"
+            filter_body = f"<ogc:And>{filter_body}</ogc:And>"
         return f"<ogc:Filter>{filter_body}</ogc:Filter>"
 
     @property

--- a/src/osdatahub/utils.py
+++ b/src/osdatahub/utils.py
@@ -206,6 +206,6 @@ def is_new_api(response: Union[dict, GrowList]) -> bool:
     if "features" in response.keys():
         return True if "crs" in response.keys() else False
     elif "geometry" in response.keys() and "properties" in response.keys():
-        return True if "GmlID" in response.keys() else False
+        return True if "GmlID" in response["properties"].keys() else False
     else:
         raise ValueError("Unknown input. Must be either a FeatureCollection or a Feature as a dict")

--- a/src/osdatahub/utils.py
+++ b/src/osdatahub/utils.py
@@ -1,5 +1,9 @@
+from typing import Union
+
 from geojson import FeatureCollection
 from shapely.geometry import LinearRing
+
+from osdatahub.grow_list import GrowList
 
 
 def clean_features(feature_list: list, geom_type: str) -> list:
@@ -194,3 +198,14 @@ def validate_in_range(value: float, minimum: float, maximum: float) -> float:
     if value < minimum or value > maximum:
         raise ValueError(f"Value should be between {minimum} and {maximum}, got {value}.")
     return value
+
+
+def is_new_api(response: Union[dict, GrowList]) -> bool:
+    if isinstance(response, GrowList) and len(response) > 0:
+        response = response.values[0]
+    if "features" in response.keys():
+        return True if "crs" in response.keys() else False
+    elif "geometry" in response.keys() and "properties" in response.keys():
+        return True if "GmlID" in response.keys() else False
+    else:
+        raise ValueError("Unknown input. Must be either a FeatureCollection or a Feature as a dict")


### PR DESCRIPTION
As the new API is rolled out, we will want to notify users of the change and prompt them to update their API key to unlock new features. 

This PR is for a utility function that determines whether a response came from the new API endpoint or the old API endpoint, and a warning displayed if the API endpoint is the old one