### PR TITLE
Added warning if user is using the old API key

### DIFF
--- a/src/osdatahub/FeaturesAPI/features_api.py
+++ b/src/osdatahub/FeaturesAPI/features_api.py
@@ -105,7 +105,7 @@ class FeaturesAPI:
         except json.decoder.JSONDecodeError:
             raise_http_error(response)
 
-        if not is_new_api(data):
+        if len(data) and not is_new_api(data):
             warnings.warn("The OS Data Hub  has updated the Features API, fixing some important bugs and adding some "
                           "new properties to all responses.\nTo access these features, consider regenerating your API "
                           "key in the OS Data Hub API dashboard. \nMore information about the update can be found at"

--- a/src/osdatahub/FeaturesAPI/features_api.py
+++ b/src/osdatahub/FeaturesAPI/features_api.py
@@ -1,4 +1,5 @@
 import json
+import warnings
 from typing import Iterable
 
 import requests
@@ -11,7 +12,7 @@ from osdatahub.FeaturesAPI.feature_products import (get_product,
 from osdatahub.filters import intersects
 from osdatahub.grow_list import GrowList
 from osdatahub.spatial_filter_types import SpatialFilterTypes
-from osdatahub.utils import features_to_geojson
+from osdatahub.utils import features_to_geojson, is_new_api
 from typeguard import check_argument_types
 
 
@@ -103,6 +104,12 @@ class FeaturesAPI:
                 n_required = min(100, limit - len(data))
         except json.decoder.JSONDecodeError:
             raise_http_error(response)
+
+        if not is_new_api(data):
+            warnings.warn("The OS Data Hub  has updated the Features API, fixing some important bugs and adding some "
+                          "new properties to all responses.\nTo access these features, consider regenerating your API "
+                          "key in the OS Data Hub API dashboard. \nMore information about the update can be found at"
+                          "osdatahub.os.uk.", DeprecationWarning)
         return features_to_geojson(data.values, self.product.geometry,
                                    self.extent.crs)
 

--- a/src/osdatahub/utils.py
+++ b/src/osdatahub/utils.py
@@ -201,6 +201,16 @@ def validate_in_range(value: float, minimum: float, maximum: float) -> float:
 
 
 def is_new_api(response: Union[dict, GrowList]) -> bool:
+    """
+    Checks whether the response came from the new API endpoint or the old API endpoint. The new endpoint responsen has
+    2 differences: it includes a "crs" item in the response geojson and each feature contains a new property called
+    'GmlID'. This function checks for these differences and returns a boolean.
+    Args:
+        response (Union[dict, GrowList]): response from the API. This could take any of 3 forms: the raw json response,
+        a single feature, or a GrowList containing features.
+
+    Returns (bool): True if response came from new endpoint, False otherwise
+    """
     if isinstance(response, GrowList) and len(response) > 0:
         response = response.values[0]
     if "features" in response.keys():
@@ -208,4 +218,5 @@ def is_new_api(response: Union[dict, GrowList]) -> bool:
     elif "geometry" in response.keys() and "properties" in response.keys():
         return True if "GmlID" in response["properties"].keys() else False
     else:
-        raise ValueError("Unknown input. Must be either a FeatureCollection or a Feature as a dict")
+        raise ValueError("Unknown input. Must be either a FeatureCollection, a Feature as a dict, or a GrowList"
+                         "containing features as dicts")

--- a/src/osdatahub/utils.py
+++ b/src/osdatahub/utils.py
@@ -1,5 +1,9 @@
+from typing import Union
+
 from geojson import FeatureCollection
 from shapely.geometry import LinearRing
+
+from osdatahub.grow_list import GrowList
 
 
 def clean_features(feature_list: list, geom_type: str) -> list:
@@ -194,3 +198,14 @@ def validate_in_range(value: float, minimum: float, maximum: float) -> float:
     if value < minimum or value > maximum:
         raise ValueError(f"Value should be between {minimum} and {maximum}, got {value}.")
     return value
+
+
+def is_new_api(response: Union[dict, GrowList]) -> bool:
+    if isinstance(response, GrowList) and len(response) > 0:
+        response = response.values[0]
+    if "features" in response.keys():
+        return True if "crs" in response.keys() else False
+    elif "geometry" in response.keys() and "properties" in response.keys():
+        return True if "GmlID" in response["properties"].keys() else False
+    else:
+        raise ValueError("Unknown input. Must be either a FeatureCollection or a Feature as a dict")

--- a/src/osdatahub/utils.py
+++ b/src/osdatahub/utils.py
@@ -202,7 +202,7 @@ def validate_in_range(value: float, minimum: float, maximum: float) -> float:
 
 def is_new_api(response: Union[dict, GrowList]) -> bool:
     """
-    Checks whether the response came from the new API endpoint or the old API endpoint. The new endpoint responsen has
+    Checks whether the response came from the new API endpoint or the old API endpoint. The new endpoint response has
     2 differences: it includes a "crs" item in the response geojson and each feature contains a new property called
     'GmlID'. This function checks for these differences and returns a boolean.
     Args:


### PR DESCRIPTION
As the new API is rolled out, we will want to notify users of the change and prompt them to update their API key to unlock new features.

This PR is for a utility function that determines whether a response came from the new API endpoint or the old API endpoint, and a warning displayed if the API endpoint is the old one