### PR TITLE
Features epsg 4329

### DIFF
--- a/src/osdatahub/FeaturesAPI/features_api.py
+++ b/src/osdatahub/FeaturesAPI/features_api.py
@@ -96,6 +96,10 @@ class FeaturesAPI:
         params = self.__params
         data = GrowList()
         n_required = min(limit, 100)
+
+        if "srsName='EPSG:4329'" in params["filter"]:
+            warnings.warn("The features API does not support EPSG:4329 and will return an empty features list.")
+
         try:
             while n_required > 0 and data.grown:
                 params.update({"count": n_required, "startIndex": len(data)})


### PR DESCRIPTION
Adds a warning when the user has an EPSG:4329 polygon in a features api call.
Resolves #29.