### PR TITLE
Removing prior notices and configuring authorship

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [1.2.11] - 2024/07/08
+- Package Resupported - Supported under new team [jmbraybrook]
+
 ## [1.2.10] - 2024/03/08
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,12 +1,5 @@
 # osdatahub <!-- omit in toc -->
 
-
-> ⚠ **Important Notice**:
-> 
-> - This Python package is no longer actively maintained and will not receive updates.
-> - It may become incompatible with future [OS Data Hub APIs](https://osdatahub.os.uk/).
-
-
 [![GitHub issues](https://img.shields.io/github/issues/OrdnanceSurvey/osdatahub)](https://github.com/OrdnanceSurvey/osdatahub/issues)
 [![Python package](https://github.com/OrdnanceSurvey/osdatahub/actions/workflows/python-package.yml/badge.svg)](https://github.com/OrdnanceSurvey/osdatahub/actions/workflows/python-package.yml)
 <a href="https://codeclimate.com/github/dchirst/osdatahub/maintainability"><img src="https://api.codeclimate.com/v1/badges/471fd53dbb22e9e28546/maintainability" /></a>
@@ -352,4 +345,4 @@ pip install -e .[dev]
 
 ## Support
 
-For any kind of issues or suggestions please see the [**documentation**](https://osdatahub.readthedocs.io/en/latest/), open a **[github issue](https://github.com/OrdnanceSurvey/osdatahub/issues)** or contact us via Email **[rapidprototyping@os.uk](mailto:rapidprototyping@os.uk)**
+For any kind of issues or suggestions please see the [**documentation**](https://osdatahub.readthedocs.io/en/latest/), open a **[github issue](https://github.com/OrdnanceSurvey/osdatahub/issues)** or contact us via Email **[datascience@os.uk](mailto:datascience@os.uk)**

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,8 @@
 [metadata]
 name = osdatahub
-version = 1.2.10
-author = OS Rapid Prototyping
-author_email = rapidprototyping@os.uk
+version = 1.2.11
+author = OS Data Science
+author_email = datascience@os.uk
 classifiers =
     Natural Language :: English
     Intended Audience :: Developers

--- a/src/osdatahub/__init__.py
+++ b/src/osdatahub/__init__.py
@@ -2,12 +2,6 @@ import os
 import json
 import logging
 
-message = """Deprecation Warning:
-- The osdatahub Python package is no longer actively maintained and will not receive updates.
-- It may become incompatible with future OS Data Hub APIs.
-"""
-logging.warning(message)
-
 os.environ["_OSDATAHUB_PROXIES"] = json.dumps({})
 
 def set_proxies(proxies):
@@ -16,7 +10,7 @@ def set_proxies(proxies):
 def get_proxies():
     return json.loads(os.environ["_OSDATAHUB_PROXIES"])
 
-__version__ = "1.2.10"
+__version__ = "1.2.11"
 
 from osdatahub.extent import Extent
 from osdatahub.FeaturesAPI import FeaturesAPI


### PR DESCRIPTION
Aim of this pull request is to update details and to confirm maintenance ongoing

**Changes**

- OS Contact Details updated to datascience@os.uk
- Version number has been advanced to [1.2.11]
- Removal of maintenance no longer supported notices