### PR TITLE
Include None type in hints for function params with default value None

### DIFF
--- a/src/osdatahub/LinkedIdentifiersAPI/linked_identifiers_api.py
+++ b/src/osdatahub/LinkedIdentifiersAPI/linked_identifiers_api.py
@@ -59,8 +59,8 @@ class LinkedIdentifiersAPI:
     def query(
             self,
             identifier: Union[int, str],
-            feature_type: str = None,
-            identifier_type: str = None,
+            feature_type: Union[str, None] = None,
+            identifier_type: Union[str, None] = None,
     ) -> dict:
         """Run a query of the OS Linked Identifiers API - looks up an
         identifier and finds its associated identifiers.

--- a/src/osdatahub/PlacesAPI/places_api.py
+++ b/src/osdatahub/PlacesAPI/places_api.py
@@ -54,7 +54,7 @@ class PlacesAPI:
     def query(
             self,
             extent: Extent,
-            output_crs: str = None,
+            output_crs: Union[str, None] = None,
             limit: int = 100,
             classification_code: Union[str, Iterable, None] = None,
             logical_status_code: Union[str, int, None] = None,

--- a/src/osdatahub/bbox.py
+++ b/src/osdatahub/bbox.py
@@ -1,4 +1,5 @@
 from dataclasses import astuple, dataclass
+from typing import Union
 
 
 @dataclass
@@ -19,7 +20,7 @@ class BBox:
     def __getitem__(self, index):
         return list(self)[index]
 
-    def to_string(self, precision: int = None) -> str:
+    def to_string(self, precision: Union[int, None] = None) -> str:
         """
         Converts bounding box into string
 

--- a/src/osdatahub/grow_list.py
+++ b/src/osdatahub/grow_list.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 class GrowList:
     """
     GrowList is a convenience class that behaves similarly to a normal
@@ -5,7 +7,7 @@ class GrowList:
     with the extend() function.
     """
 
-    def __init__(self, values: list = None):
+    def __init__(self, values: Union[list, None] = None):
         self.values = values if values else []
         self.size = [len(self.values)]
 


### PR DESCRIPTION
Adds `None` type hints to function parameters with default values of `None`. Fixes #120 