### PR TITLE
Add user agent tag to osdatahub python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.3.1] - 2025/06/10
+- Added User Agent tag for the python wrapper on requests to the OS Data Hub API
+- Added contributions from [aricooperdavis] - Include None type in hints for function params with default value None
+
 ## [1.3.0] - 2024/11/18
 - Removing Support for Python 3.7
 - Adding Support for Python 3.12, 3.13

--- a/recipes/meta.yaml
+++ b/recipes/meta.yaml
@@ -1,6 +1,6 @@
 
 {% set name = "osdatahub" %}
-{% set version = "1.3.0" %}
+{% set version = "1.3.1" %}
 
 
 package:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = osdatahub
-version = 1.3.0
+version = 1.3.1
 author = OS Data Science
 author_email = datascience@os.uk
 classifiers =

--- a/src/osdatahub/DownloadsAPI/downloads_api.py
+++ b/src/osdatahub/DownloadsAPI/downloads_api.py
@@ -54,7 +54,7 @@ class _DownloadObj:
 
         for _ in range(retries):
             try:
-                header = {'User-Agent': osdatahub.USER_AGENT_TAG}
+                header = {'User-Agent': 'osdatahub-python'}
                 response = requests.get(
                     self.url, stream=True, headers=header, proxies=osdatahub.get_proxies())
                 response.raise_for_status()

--- a/src/osdatahub/DownloadsAPI/downloads_api.py
+++ b/src/osdatahub/DownloadsAPI/downloads_api.py
@@ -54,8 +54,9 @@ class _DownloadObj:
 
         for _ in range(retries):
             try:
+                header = {'User-Agent': osdatahub.USER_AGENT_TAG}
                 response = requests.get(
-                    self.url, stream=True, proxies=osdatahub.get_proxies())
+                    self.url, stream=True, headers=header, proxies=osdatahub.get_proxies())
                 response.raise_for_status()
                 expected_size = int(response.headers.get('content-length'))
                 current_size = 0

--- a/src/osdatahub/requests_wrapper.py
+++ b/src/osdatahub/requests_wrapper.py
@@ -5,8 +5,7 @@ Information and inspiration from https://blog.petrzemek.net/2018/04/22/on-incomp
 
 import requests
 
-USER_AGENT_TAG = 'osdatahub-python'
-
+_USER_AGENT_TAG = 'osdatahub-python'
 
 def check_length(func):
     """
@@ -48,7 +47,7 @@ def add_user_agent_tag(kwargs):
     if kwargs.get('headers') is None:
         kwargs['headers'] = {}
 
-    kwargs['headers'].update({'User-Agent': USER_AGENT_TAG})
+    kwargs['headers'].update({'User-Agent': _USER_AGENT_TAG})
 
     return kwargs
 

--- a/src/osdatahub/requests_wrapper.py
+++ b/src/osdatahub/requests_wrapper.py
@@ -5,6 +5,8 @@ Information and inspiration from https://blog.petrzemek.net/2018/04/22/on-incomp
 
 import requests
 
+USER_AGENT_TAG = 'osdatahub-python'
+
 
 def check_length(func):
     """
@@ -38,6 +40,17 @@ def check_length(func):
         return response
     return wrapper
 
+def add_user_agent_tag(kwargs):
+    """
+    Adds a User-Agent header to the request if it is not already present.
+    """
+
+    if kwargs.get('headers') is None:
+        kwargs['headers'] = {}
+    if 'User-Agent' not in kwargs['headers']:
+        kwargs['headers']['User-Agent'] = USER_AGENT_TAG
+
+    return kwargs
 
 @check_length
 def get(*args, **kwargs):
@@ -54,6 +67,7 @@ def get(*args, **kwargs):
     Raises:
         IOError: If the content length check fails.
     """
+    kwargs = add_user_agent_tag(kwargs)
     return requests.get(*args, **kwargs)
 
 
@@ -72,4 +86,5 @@ def post(*args, **kwargs):
     Raises:
         IOError: If the content length check fails.
     """
+    kwargs = add_user_agent_tag(kwargs)
     return requests.post(*args, **kwargs)

--- a/src/osdatahub/requests_wrapper.py
+++ b/src/osdatahub/requests_wrapper.py
@@ -42,13 +42,13 @@ def check_length(func):
 
 def add_user_agent_tag(kwargs):
     """
-    Adds a User-Agent header to the request if it is not already present.
+    Adds a User-Agent header to the request so that it matches the USER AGENT TAG.
     """
 
     if kwargs.get('headers') is None:
         kwargs['headers'] = {}
-    if 'User-Agent' not in kwargs['headers']:
-        kwargs['headers']['User-Agent'] = USER_AGENT_TAG
+
+    kwargs['headers'].update({'User-Agent': USER_AGENT_TAG})
 
     return kwargs
 


### PR DESCRIPTION
Changes

Adding a user agent tag to the OS Datahub Python Wrapper so that requests made using this codebase can be differentiated vs other ways of making requests to the API. 

